### PR TITLE
Remove Ston from testing because it is deprecated

### DIFF
--- a/src/Bloc-Serialization-Stash/BlElement.extension.st
+++ b/src/Bloc-Serialization-Stash/BlElement.extension.st
@@ -36,10 +36,8 @@ BlElement >> allSetterAndGettersForMyStashIdentifier [
 BlElement >> allSetterAndGettersForMyStashLayout [
 
 	<stashAccessors>
-	self layout == self defaultLayout ifFalse: [
-		^ { #layout } ].
+	self layout = self defaultLayout ifFalse: [ ^ { #layout } ].
 	^ {  }
-	
 ]
 
 { #category : #'*Bloc-Serialization-Stash' }

--- a/src/Bloc-Serialization-Tests/BlocSerializationTests.class.st
+++ b/src/Bloc-Serialization-Tests/BlocSerializationTests.class.st
@@ -19,7 +19,7 @@ BlocSerializationTests >> serializeThenMaterialize: aBlElement withSerializer: a
 { #category : #'as yet unclassified' }
 BlocSerializationTests >> serializersToTest [
 
-	^ TBlSerializer users
+	^ { BlStashSerializer }
 ]
 
 { #category : #utilities }


### PR DESCRIPTION
- small fix on layout to remove the unacessary lines of code in stash